### PR TITLE
add copyfiles command

### DIFF
--- a/cmd/all/all.go
+++ b/cmd/all/all.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/rclone/rclone/cmd/cmount"
 	_ "github.com/rclone/rclone/cmd/config"
 	_ "github.com/rclone/rclone/cmd/copy"
+	_ "github.com/rclone/rclone/cmd/copyfiles"
 	_ "github.com/rclone/rclone/cmd/copyto"
 	_ "github.com/rclone/rclone/cmd/copyurl"
 	_ "github.com/rclone/rclone/cmd/cryptcheck"

--- a/cmd/copyfiles/copyfiles.go
+++ b/cmd/copyfiles/copyfiles.go
@@ -1,0 +1,44 @@
+// Package copyfiles provides the copyfiles command.
+package copyfiles
+
+import (
+	"context"
+	"github.com/rclone/rclone/fs/sync"
+	"strings"
+
+	"github.com/rclone/rclone/cmd"
+	"github.com/rclone/rclone/fs/config/flags"
+	"github.com/spf13/cobra"
+)
+
+var (
+	filesList = ""
+)
+
+func init() {
+	cmd.Root.AddCommand(commandDefinition)
+	cmdFlags := commandDefinition.Flags()
+	flags.StringVarP(cmdFlags, &filesList, "files-list", "", "", "Read list of source-file names from file without any processing of lines")
+}
+
+var commandDefinition = &cobra.Command{
+	Use:   "copyfiles source:path dest:path --files-list files.txt",
+	Short: `Copy files from source to dest, skipping identical files.`,
+	// Note: "|" will be replaced by backticks below
+	Long: strings.ReplaceAll(`
+Copy the source to the destination.  Does not transfer files that are
+identical on source and destination, testing by size and modification
+time or MD5SUM.  Doesn't delete files from the destination. If you
+want to also delete files from destination, to make it match source,
+use the [sync](/commands/rclone_sync/) command instead.
+
+Only files contained in files-list will be copied.
+`, "|", "`"),
+	Run: func(command *cobra.Command, args []string) {
+		cmd.CheckArgs(2, 2, command, args)
+		fsrc, _, fdst := cmd.NewFsSrcFileDst(args)
+		cmd.Run(true, true, command, func() error {
+			return sync.CopyFiles(context.Background(), fdst, fsrc, filesList)
+		})
+	},
+}


### PR DESCRIPTION
@phildav Tested with an S3 from a big customer and a files-list of 10k+ items, we start copying immediately (1s).

I went simple and assume that the file does not exist on the target (this is our case in nominal usage), worst case we overwrite the file but we do not really care.

We also avoid the lookup on the target's bucket.

I can walk you through the code if you want
