### PR TITLE
remove heuristic around directory listing

### DIFF
--- a/fs/walk/walk.go
+++ b/fs/walk/walk.go
@@ -154,8 +154,7 @@ func ListR(ctx context.Context, f fs.Fs, path string, includeAll bool, maxLevel 
 	if doListR == nil || // ...no ListR
 		fi.HaveFilesFrom() || // ...using --files-from
 		maxLevel >= 0 || // ...using bounded recursion
-		len(fi.Opt.ExcludeFile) > 0 || // ...using --exclude-file
-		fi.UsesDirectoryFilters() { // ...using any directory filters
+		len(fi.Opt.ExcludeFile) > 0 { // ...using --exclude-file
 		return listRwalk(ctx, f, path, includeAll, maxLevel, listType, fn)
 	}
 	ctx = filter.SetUseFilter(ctx, f.Features().FilterAware && !includeAll) // make filter-aware backends constrain List


### PR DESCRIPTION
If rclone detect a directory filter it will prefer listRwalk instead of listR.

The idea is to skip listing the content of unnecessary directory.

In practice for our S3/GCS with millions of objects it makes a huge consumption in memory as rclone will build the tree in memory.

See discussion here:
https://forum.rclone.org/t/high-memory-usage-of-s3-during-listing/35376/10
